### PR TITLE
fix/remove-blocking-loops

### DIFF
--- a/src/dialogflow/sessions_client_streaming.rs
+++ b/src/dialogflow/sessions_client_streaming.rs
@@ -147,10 +147,8 @@ impl SessionsClient {
                         streaming_recognize_result?.into_inner();
 
                     trace!("streaming_detect_intent_async_stream: entering loop");
-                    loop {
-                        if let Some(streaming_detect_intent_response) = response_stream.message().await? {
-                            yield streaming_detect_intent_response;
-                        }
+                    while let Some(streaming_detect_intent_response) = response_stream.message().await? {
+                        yield streaming_detect_intent_response;
                     }
                     trace!("streaming_detect_intent_async_stream: leaving loop");
                 }
@@ -177,11 +175,9 @@ impl SessionsClient {
             let mut response_stream: Streaming<StreamingDetectIntentResponse> =
                 streaming_recognize_result?.into_inner();
 
-            loop {
-                if let Some(streaming_detect_intent_response) = response_stream.message().await? {
-                    if let Some(result_sender) = &self.result_sender {
-                        result_sender.send(streaming_detect_intent_response).await?;
-                    }
+            while let Some(streaming_detect_intent_response) = response_stream.message().await? {
+                if let Some(result_sender) = &self.result_sender {
+                    result_sender.send(streaming_detect_intent_response).await?;
                 }
             }
         }

--- a/src/speechtotext/recognizer.rs
+++ b/src/speechtotext/recognizer.rs
@@ -186,10 +186,8 @@ impl Recognizer {
                         streaming_recognize_result?.into_inner();
 
                     trace!("streaming_recognize: entering loop");
-                    loop {
-                        if let Some(streaming_recognize_response) = response_stream.message().await? {
-                            yield streaming_recognize_response;
-                        }
+                    while let Some(streaming_recognize_response) = response_stream.message().await? {
+                        yield streaming_recognize_response;
                     }
                     trace!("streaming_recognize: leaving loop");
                 }
@@ -213,11 +211,9 @@ impl Recognizer {
             let mut response_stream: Streaming<StreamingRecognizeResponse> =
                 streaming_recognize_result?.into_inner();
 
-            loop {
-                if let Some(streaming_recognize_response) = response_stream.message().await? {
-                    if let Some(result_sender) = &self.result_sender {
-                        result_sender.send(streaming_recognize_response).await?;
-                    }
+            while let Some(streaming_recognize_response) = response_stream.message().await? {
+                if let Some(result_sender) = &self.result_sender {
+                    result_sender.send(streaming_recognize_response).await?;
                 }
             }
         }

--- a/src/speechtotext/recognizer_beta.rs
+++ b/src/speechtotext/recognizer_beta.rs
@@ -201,10 +201,8 @@ impl Recognizer {
                         streaming_recognize_result?.into_inner();
 
                     trace!("streaming_recognize: entering loop");
-                    loop {
-                        if let Some(streaming_recognize_response) = response_stream.message().await? {
-                            yield streaming_recognize_response;
-                        }
+                    while let Some(streaming_recognize_response) = response_stream.message().await? {
+                        yield streaming_recognize_response;
                     }
                     trace!("streaming_recognize: leaving loop");
                 }
@@ -228,11 +226,9 @@ impl Recognizer {
             let mut response_stream: Streaming<StreamingRecognizeResponse> =
                 streaming_recognize_result?.into_inner();
 
-            loop {
-                if let Some(streaming_recognize_response) = response_stream.message().await? {
-                    if let Some(result_sender) = &self.result_sender {
-                        result_sender.send(streaming_recognize_response).await?;
-                    }
+            while let Some(streaming_recognize_response) = response_stream.message().await? {
+                if let Some(result_sender) = &self.result_sender {
+                    result_sender.send(streaming_recognize_response).await?;
                 }
             }
         }


### PR DESCRIPTION
This issue isn't too bad for single tasks, but for things such as webservers this causes the entire server to hang while awaiting a response undoing the async.
Have tested with the speech-to-text bi-directional streaming and it does work in our use case.