### PR TITLE
fix/dropping-sender-to-end-stream

### DIFF
--- a/src/dialogflow/sessions_client.rs
+++ b/src/dialogflow/sessions_client.rs
@@ -54,8 +54,8 @@ impl SessionsClient {
 
     /// Returns sender than can be used to stream in audio bytes.
     pub fn get_audio_sink(&mut self) -> Option<mpsc::Sender<StreamingDetectIntentRequest>> {
-        if let Some(audio_sender) = &self.audio_sender {
-            Some(audio_sender.clone())
+        if let Some(audio_sender) = self.audio_sender.take() {
+            Some(audio_sender)
         } else {
             None
         }

--- a/src/dialogflow/sessions_client_streaming.rs
+++ b/src/dialogflow/sessions_client_streaming.rs
@@ -77,8 +77,8 @@ impl SessionsClient {
 
     /// Returns sender than can be used to stream in audio bytes.
     pub fn get_audio_sink(&mut self) -> Option<mpsc::Sender<StreamingDetectIntentRequest>> {
-        if let Some(audio_sender) = &self.audio_sender {
-            Some(audio_sender.clone())
+        if let Some(audio_sender) = self.audio_sender.take() {
+            Some(audio_sender)
         } else {
             None
         }

--- a/src/speechtotext/recognizer.rs
+++ b/src/speechtotext/recognizer.rs
@@ -138,8 +138,8 @@ impl Recognizer {
 
     /// Returns sender than can be used to stream in audio bytes.
     pub fn get_audio_sink(&mut self) -> Option<mpsc::Sender<StreamingRecognizeRequest>> {
-        if let Some(audio_sender) = &self.audio_sender {
-            Some(audio_sender.clone())
+        if let Some(audio_sender) = self.audio_sender.take() {
+            Some(audio_sender)
         } else {
             None
         }

--- a/src/speechtotext/recognizer_beta.rs
+++ b/src/speechtotext/recognizer_beta.rs
@@ -153,8 +153,8 @@ impl Recognizer {
 
     /// Returns sender than can be used to stream in audio bytes.
     pub fn get_audio_sink(&mut self) -> Option<mpsc::Sender<StreamingRecognizeRequest>> {
-        if let Some(audio_sender) = &self.audio_sender {
-            Some(audio_sender.clone())
+        if let Some(audio_sender) = self.audio_sender.take() {
+            Some(audio_sender)
         } else {
             None
         }


### PR DESCRIPTION
### Depends on https://github.com/jabber-tools/google-cognitive-apis/pull/3

With the combination of this and the merging of https://github.com/jabber-tools/google-cognitive-apis/pull/3, dropping a sender should send an `END_STREAM` signal. 

In Speech-to-text streaming this is essential as it allows you to signal the end of an audio stream and receive a response without waiting for a timeout (paying for extra billable time, and leading to latency for users).

